### PR TITLE
Enable DXTn in ReactOS by default, no more patent

### DIFF
--- a/dll/3rdparty/CMakeLists.txt
+++ b/dll/3rdparty/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-if(NSWPAT)
-    add_subdirectory(dxtn)
-endif()
+
+add_subdirectory(dxtn)
+
 
 add_subdirectory(libjpeg)
 add_subdirectory(libpng)


### PR DESCRIPTION
Enable DXTn in ReactOS by default, as it is no longer protected by the patent.

see https://jira.reactos.org/browse/CORE-13455 for the details.